### PR TITLE
Updates for NIRView 2.0 compatibility

### DIFF
--- a/gui/gui_place_sources_detectors.m
+++ b/gui/gui_place_sources_detectors.m
@@ -111,7 +111,8 @@ end
 
 % find fiducial files
 fid_loc = what('fiducials');
-fids = dir([fid_loc.path '/fiducials_*']);
+foote = fid_loc.path;
+fids = dir([foote '/fiducials_*']);
 varnames = {'Select System'};
 for i=1:size(fids)
     varnames{i+1} = fids(i).name(11:end-2);

--- a/toolbox/meshing/image2mesh_cgal/RunCGALMeshGenerator.m
+++ b/toolbox/meshing/image2mesh_cgal/RunCGALMeshGenerator.m
@@ -74,7 +74,13 @@ eval(makemeshcommand);
 % Read the resulting mesh
 [e p] = readMEDIT(tmpmeshfn);
 if isfield(param,'Offset')
-    p = p + repmat(param.Offset,size(p,1),1);
+    if isfield(param,'TransformMatrix')
+        transformM = [param.TransformMatrix(1:3);param.TransformMatrix(4:6);param.TransformMatrix(7:9)]
+        finalOffset = param.Offset*transformM
+    else
+        finalOffset = param.Offset;
+    end
+    p = p + repmat(finalOffset,size(p,1),1);
 end
 
 % Remove possible extra nodes that might be left out in 'p' list

--- a/toolbox/meshing/image2mesh_cgal/image2mesh_gui.m
+++ b/toolbox/meshing/image2mesh_cgal/image2mesh_gui.m
@@ -904,7 +904,7 @@ function sdbrowsebutton_Callback(hObject, eventdata, handles)
 % eventdata  reserved - to be defined in a future version of MATLAB
 % handles    structure with handles and user data (see GUIDATA)
 [fn, pathname] = uigetfile( ...
-    {'*.txt;*.csv','Text Files (*.txt,*.csv)';'*.*','All Files (*.*)'}, ...
+    {'*.txt;*.csv;*.fcsv','Text Files (*.txt,*.csv,*.fcsv)';'*.*','All Files (*.*)'}, ...
    'Pick a file');
 if isequal(fn,0)
     warning('You need to select an image file!');
@@ -927,9 +927,13 @@ end
 function UpdateSDFileInfo(hObject,eventdata,handles)
 set(handles.sdfilename,'ForegroundColor',[0 0 0]);
 sdfname = get(handles.sdfilename,'String');
-if strcmp(sdfname(end-2:end),'csv')
+if strcmp(sdfname(end-3:end),'.csv')
     s = importdata(sdfname);
     handles.sdcoords = [s.data(:,2) s.data(:,3) s.data(:,4)];
+elseif strcmp(sdfname(end-4:end),'.fcsv') % Fiducials list from 3DSlicer
+    fid=fopen(get(handles.sdfilename,'String'),'rt');
+    s=textscan(fid,'%s %f %f %f %n %n %n %n %n %n %n %s %s','Delimiter',',','MultipleDelimsAsOne',1,'CommentStyle','#');
+    handles.sdcoords = [s{2} s{3} s{4}];
 else
     fid=fopen(get(handles.sdfilename,'String'),'rt');
     s=textscan(fid,'%f,%f,%f,%f');

--- a/toolbox/meshing/image2mesh_cgal/image2mesh_gui.m
+++ b/toolbox/meshing/image2mesh_cgal/image2mesh_gui.m
@@ -318,8 +318,13 @@ regions = unique(mask(:));
 s={};
 if ~isempty(info)
     s{1} = 'Info from file header:';
-    s{2} = sprintf('Rows: %d, Cols: %d, Slices: %d',info.Dimensions(1), ...
+    if isfield(info,'Dimensions')
+        set(handles.nrows,  'String',num2str(info.Dimensions(1)));
+        set(handles.ncols,  'String',num2str(info.Dimensions(2)));
+        set(handles.nslices,'String',num2str(info.Dimensions(3)));
+        s{end+1} = sprintf('Rows: %d, Cols: %d, Slices: %d',info.Dimensions(1), ...
         info.Dimensions(2), info.Dimensions(3));
+    end
     if isfield(info,'PixelDimensions')
         set(handles.xpixel,'String',num2str(info.PixelDimensions(1)));
         set(handles.ypixel,'String',num2str(info.PixelDimensions(2)));
@@ -333,14 +338,15 @@ if ~isempty(info)
         set(handles.zpixel,'String','');
         UpdateTetAndFacetSize(hObject,handles,0);
     end
-    if isfield(info,'Dimensions')
-        set(handles.nrows,  'String',num2str(info.Dimensions(1)));
-        set(handles.ncols,  'String',num2str(info.Dimensions(2)));
-        set(handles.nslices,'String',num2str(info.Dimensions(3)));
-    end
     if isfield(info,'Offset')
-        s{end+1} = sprintf('Offset: [%.2f %.2f %.2f]',info.Offset);
-        handles.offset = info.Offset;
+        if isfield(info,'TransformMatrix')
+            transformM = [info.TransformMatrix(1:3);info.TransformMatrix(4:6);info.TransformMatrix(7:9)]
+            finalOffset = info.Offset*transformM
+        else
+            finalOffset = info.Offset;
+        end
+        s{end+1} = sprintf('Offset: [%.2f %.2f %.2f]',finalOffset);
+        handles.offset = finalOffset;
     end
     set(handles.imageinfotxt,'String',s);
 end


### PR DESCRIPTION
1. fcsv reader for S/D (fiducials in Slicer)
2. Use TransformMatrix information 
3. Handle multiple versions of NIRFAST